### PR TITLE
Fix #5 leave command bug

### DIFF
--- a/hamper/plugins/channel_utils.py
+++ b/hamper/plugins/channel_utils.py
@@ -23,18 +23,20 @@ class ChannelUtils(ChatCommandPlugin):
 
     class LeaveCommand(Command):
         name = 'leave'
-        regex = r'^leave (#?[-_a-zA-Z0-9])?$'
+        regex = r'^leave( #?[-_a-zA-Z0-9]+)?$'
 
         short_desc = 'leave [#channel] - Ask the bot to leave.'
         long_desc = 'If channel is ommited, leave the current channel.'
 
         def command(self, bot, comm, groups):
-            """Join a channel, and say you did."""
+            """Say goodbye and leave channel."""
             chan = groups[0]
+            chan = chan.lstrip() # With the change in regex the match will have a space in front
             if chan is None:
                 chan = comm['channel']
             if not chan.startswith('#'):
                 chan = '#' + chan
+            comm['channel'] = chan # The bot should say goodbye in the channel that it leaves
             bot.reply(comm, 'Bye!')
             bot.leave(chan)
 


### PR DESCRIPTION
Hi

I found a link to this repository on /r/learnprogramming and looking at the issues I figured I would give this one(#5) a go.

There were several issues with the existing regex:
- "leave" without channel needed a trailing space
- the given channel name could only be one character
  I've changed the regex to solve these issues, but the new regex does leave a trailing space at the start which needs to be removed. There might be a neater solution. 

I've also changed the existing comment and changed it so the bot says "goodbye" in the channel it leaves, not in the channel where the command is given.

If there are any problems with this commit or things I could have done better I would like to hear them.

Thanks
